### PR TITLE
fix(BndersBnB): refactor root node preprocessing architecture with type dispatch

### DIFF
--- a/src/BendersBase/src/BendersBase.jl
+++ b/src/BendersBase/src/BendersBase.jl
@@ -22,6 +22,7 @@ export Data, AbstractData
 export AbstractMaster, AbstractMip
 export AbstractOracle, AbstractOracleParam, AbstractTypicalOracle, BasicOracleParam
 export AbstractBendersSeq, AbstractBendersCallback
+export AbstractRootNodePreprocessing
 export Seq, SeqInOut
 export TerminationStatus, NotSolved, TimeLimit, Optimal, InfeasibleOrNumericalIssue
 export TimeLimitException, UnexpectedModelStatusException, UndefError, AlgorithmException

--- a/src/BendersBase/src/algorithms/BendersBnB.jl
+++ b/src/BendersBase/src/algorithms/BendersBnB.jl
@@ -80,20 +80,7 @@ function solve!(env::BendersBnB)
     log.start_time = time()
     
     # Apply root node preprocessing if specified
-    root_node_time = 0.0
-    if isa(env.root_preprocessing, RootNodePreprocessing)
-        root_node_time = root_node_processing!(env.data, env.master, env.root_preprocessing)
-    end
-    
-    # Apply disjunctive root node preprocessing if specified
-    if param.disjunctive_root_process
-        # Update root_preprocessing params
-        env.root_preprocessing.params.time_limit -= root_node_time
-        env.root_preprocessing.oracle = env.user_callback.oracle
-
-        disjunctive_root_node_time = root_node_processing!(env.data, env.master, env.root_preprocessing)
-        root_node_time += disjunctive_root_node_time
-    end
+    root_node_time = root_node_processing!(env.data, env.master, env.root_preprocessing)
     
     # Set up lazy callback
     function lazy_callback_wrapper(cb_data)
@@ -144,10 +131,10 @@ function solve!(env::BendersBnB)
         @info "Objective value: $(env.obj_value)"
         @info "Relative gap: $(JuMP.relative_gap(env.master.model))"
         @info "Lazy cuts added: $(log.n_lazy_cuts)"
-        if typeof(env.user_callback.oracle) <: AbstractDisjunctiveOracle
-            @info "Disjunctive cuts added: $(length(env.user_callback.oracle.disjunctiveCuts))"
-            env.user_callback.oracle.oracle_param.add_benders_cuts_to_master != 0 && @info "Byproduct Benders cuts added: $(log.n_user_cuts - length(env.user_callback.oracle.disjunctiveCuts))"
-        end
+        # if typeof(env.user_callback.oracle) <: AbstractDisjunctiveOracle
+        #     @info "Disjunctive cuts added: $(length(env.user_callback.oracle.disjunctiveCuts))"
+        #     env.user_callback.oracle.oracle_param.add_benders_cuts_to_master != 0 && @info "Byproduct Benders cuts added: $(log.n_user_cuts - length(env.user_callback.oracle.disjunctiveCuts))"
+        # end
     end
     
     return deepcopy(env.obj_value), elapsed_time

--- a/src/BendersBase/src/algorithms/callback/preprocessing.jl
+++ b/src/BendersBase/src/algorithms/callback/preprocessing.jl
@@ -43,9 +43,21 @@ mutable struct RootNodePreprocessing <: AbstractRootNodePreprocessing
 end
 
 """
+    root_node_processing!(data::Data, master::AbstractMaster, root_preprocessing::NoRootNodePreprocessing) -> Float64
+
+No-op implementation for NoRootNodePreprocessing.
+
+# Returns
+- `Float64`: 0.0 (no time spent)
+"""
+function root_node_processing!(data::Data, master::AbstractMaster, root_preprocessing::NoRootNodePreprocessing)
+    return 0.0
+end
+
+"""
     root_node_processing!(data::Data, master::AbstractMaster, root_preprocessing::RootNodePreprocessing)
 
-Process the root node of the branch-and-bound tree by temporarily relaxing integrality 
+Process the root node of the branch-and-bound tree by temporarily relaxing integrality
 constraints and generating initial Benders cuts.
 
 # Arguments
@@ -60,13 +72,13 @@ function root_node_processing!(data::Data, master::AbstractMaster, root_preproce
     root_param = deepcopy(root_preprocessing.params)
 
     undo = relax_integrality(master.model)
-    
+
     root_node_time = @elapsed begin
         BendersRootSeq = root_preprocessing.seq_type(data, master, root_preprocessing.oracle; param=root_param)
         solve!(BendersRootSeq)
     end
-    
+
     undo()
-    
+
     return root_node_time
 end

--- a/src/BendersBase/src/utils/utilsBnB.jl
+++ b/src/BendersBase/src/utils/utilsBnB.jl
@@ -78,16 +78,14 @@ These parameters allow fine-tuning of the Benders algorithm performance.
 mutable struct BendersBnBParam <: AbstractBendersBnBParam
     time_limit::Float64
     gap_tolerance::Float64
-    disjunctive_root_process:: Bool
     verbose::Bool
 
-    function BendersBnBParam(; 
-                        time_limit::Float64 = 7200.0, 
-                        gap_tolerance::Float64 = 1e-6, 
-                        disjunctive_root_process = false,
+    function BendersBnBParam(;
+                        time_limit::Float64 = 7200.0,
+                        gap_tolerance::Float64 = 1e-6,
                         verbose::Bool = true
-                        ) 
-        new(time_limit, gap_tolerance, disjunctive_root_process, verbose)
+                        )
+        new(time_limit, gap_tolerance, verbose)
     end
 end 
 

--- a/src/BendersLibrary/src/BendersLibrary.jl
+++ b/src/BendersLibrary/src/BendersLibrary.jl
@@ -8,7 +8,7 @@ using CPLEX
 using Printf
 using SparseArrays
 
-import BendersBase: solve!, generate_cuts, update_upper_bound_and_gap!, is_terminated, print_iteration_info, set_parameter!
+import BendersBase: solve!, generate_cuts, update_upper_bound_and_gap!, is_terminated, print_iteration_info, set_parameter!, root_node_processing!
 
 include("types.jl")
 include("utils/utils.jl")

--- a/src/BendersLibrary/src/algorithms/algorithms.jl
+++ b/src/BendersLibrary/src/algorithms/algorithms.jl
@@ -1,2 +1,3 @@
-include("BendersSeqInOut.jl") 
+include("preprocessing.jl")
+include("BendersSeqInOut.jl")
 include("SpecializedBendersSeq.jl") 

--- a/src/BendersLibrary/src/algorithms/preprocessing.jl
+++ b/src/BendersLibrary/src/algorithms/preprocessing.jl
@@ -1,0 +1,105 @@
+export DisjunctiveRootNodePreprocessing
+
+"""
+    DisjunctiveRootNodePreprocessing <: AbstractRootNodePreprocessing
+
+Root node preprocessing using a disjunctive oracle for generating stronger initial cuts.
+
+# Fields
+- `classical_oracle::AbstractTypicalOracle`: Oracle for the first phase (classical preprocessing)
+- `disjunctive_oracle::AbstractDisjunctiveOracle`: Oracle for the second phase (disjunctive preprocessing)
+- `seq_type::Type{<:AbstractBendersSeq}`: Type of sequential Benders algorithm to use
+- `params::AbstractBendersSeqParam`: Parameters for the sequential algorithm
+
+# Constructor
+```julia
+DisjunctiveRootNodePreprocessing(
+    classical_oracle::AbstractTypicalOracle,
+    disjunctive_oracle::AbstractDisjunctiveOracle;
+    seq_type::Type{<:AbstractBendersSeq} = BendersSeq,
+    params::AbstractBendersSeqParam = BendersSeqParam()
+)
+```
+
+# Examples
+```julia
+# Create classical oracle for first phase
+classical_oracle = ClassicalOracle(data)
+
+# Create disjunctive oracle for second phase
+disj_oracle = DisjunctiveOracle(data, [oracle_kappa, oracle_nu])
+
+# Create two-phase preprocessing
+preprocessing = DisjunctiveRootNodePreprocessing(classical_oracle, disj_oracle)
+
+# Use with BendersBnB
+algorithm = BendersBnB(data, master, preprocessing, lazy_callback, user_callback)
+```
+
+See also: [`RootNodePreprocessing`](@ref), [`DisjunctiveOracle`](@ref)
+"""
+mutable struct DisjunctiveRootNodePreprocessing <: AbstractRootNodePreprocessing
+    classical_oracle::AbstractTypicalOracle
+    disjunctive_oracle::AbstractDisjunctiveOracle
+    seq_type::Type{<:AbstractBendersSeq}
+    params::AbstractBendersSeqParam
+
+    function DisjunctiveRootNodePreprocessing(
+        classical_oracle::AbstractTypicalOracle,
+        disjunctive_oracle::AbstractDisjunctiveOracle;
+        seq_type::Type{<:AbstractBendersSeq} = BendersSeq,
+        params::AbstractBendersSeqParam = BendersSeqParam()
+    )
+        new(classical_oracle, disjunctive_oracle, seq_type, params)
+    end
+end
+
+"""
+    root_node_processing!(data::Data, master::AbstractMaster, preprocessing::DisjunctiveRootNodePreprocessing) -> Float64
+
+Perform two-phase root node preprocessing.
+
+This method relaxes integrality constraints once and executes two sequential phases:
+1. Classical oracle preprocessing to generate initial cuts
+2. Disjunctive oracle preprocessing to generate strengthened cuts
+
+The time limit for the second phase is automatically adjusted based on the time
+consumed by the first phase.
+
+# Arguments
+- `data::Data`: Problem data
+- `master::AbstractMaster`: Master problem
+- `preprocessing::DisjunctiveRootNodePreprocessing`: Two-phase preprocessing configuration
+
+# Returns
+- `Float64`: Total time spent on both preprocessing phases
+"""
+function root_node_processing!(data::Data, master::AbstractMaster, preprocessing::DisjunctiveRootNodePreprocessing)
+    total_time = 0.0
+
+    # Relax integrality once for both phases
+    undo = relax_integrality(master.model)
+
+    # Phase 1: Classical oracle preprocessing
+    classical_time = @elapsed begin
+        classical_param = deepcopy(preprocessing.params)
+        classical_seq = preprocessing.seq_type(data, master, preprocessing.classical_oracle; param=classical_param)
+        solve!(classical_seq)
+    end
+    total_time += classical_time
+
+    # Phase 2: Disjunctive oracle preprocessing with remaining time
+    remaining_param = deepcopy(preprocessing.params)
+    remaining_param.time_limit -= classical_time
+
+    disjunctive_time = @elapsed begin
+        disjunctive_seq = preprocessing.seq_type(data, master, preprocessing.disjunctive_oracle; param=remaining_param)
+        solve!(disjunctive_seq)
+    end
+    total_time += disjunctive_time
+
+    # Restore integrality
+    undo()
+
+    return total_time
+end


### PR DESCRIPTION
  ## Summary

  - Refactor root node preprocessing architecture to remove disjunctive-specific logic from BendersBase
  - Move disjunctive preprocessing implementation to BendersLibrary where it belongs
  - Introduce type-based dispatch pattern for cleaner separation of concerns