### PR TITLE
Clarify fallback constructor and error message for AbstractTypicalOra…

### DIFF
--- a/src/BendersBase/src/modules/oracles/oracleTypicalSeparable.jl
+++ b/src/BendersBase/src/modules/oracles/oracleTypicalSeparable.jl
@@ -1,5 +1,43 @@
 export SeparableOracle, SeparableOracleParam
 
+"""
+Fallback constructor for subtypes of [`AbstractTypicalOracle`](@ref).
+
+This method is invoked when the user attempts to construct a `SeparableOracle`
+with a concrete oracle subtype `T` that does **not** define the required
+type-call constructor:
+
+    T(data::AbstractData, master::AbstractMaster;
+      customize = customize_sub_model!, scen_idx::Int, param::AbstractOracleParam)
+
+Calling this fallback indicates that the oracle type `T` has not implemented
+the interface expected by `SeparableOracle`. Any concrete oracle intended for
+use with `SeparableOracle` must therefore define a constructor matching the
+signature above.
+
+# Errors
+Throws an error indicating that the subtype `T` must provide the required
+constructor.
+"""
+(::Type{T})(data::AbstractData, master::AbstractMaster;
+            customize = customize_sub_model!,
+            scen_idx::Int,
+            param::AbstractOracleParam) where T <: AbstractTypicalOracle =
+    throw(UndefError(
+        """
+        Oracle subtype $(T) does not implement the required constructor
+        needed by `SeparableOracle`.
+
+        Expected constructor signature:
+
+          $(T)(data::AbstractData, master::AbstractMaster;
+              customize = customize_sub_model!, scen_idx::Int, param::AbstractOracleParam)
+
+        Define this constructor for $(T) in order to use it with `SeparableOracle`.
+        """
+    ))
+
+
 mutable struct SeparableOracleParam <: AbstractOracleParam
     # may contain parameters for scenario handling.
 end

--- a/src/BendersBase/src/utils/utilsInterface.jl
+++ b/src/BendersBase/src/utils/utilsInterface.jl
@@ -64,7 +64,7 @@ scenario index `scen_idx`, the method should:
 
 By default, this method throws an `UndefError`, indicating that no implementation
 exists for the provided argument types. Users must define their own specialized
-method if they want to used any model-based oracle. For example:
+method if they want to use any model-based oracle. For example:
 
 ```julia
 function customize_sub_model!(model::Model, data::MyDataType, scen_idx::Int; u, v)
@@ -89,7 +89,7 @@ subproblem formulation.
 Notes
 - This function must be implemented by the user to construct model-based oracles.
 """
-function customize_sub_model!(model::Model, data::AbstractData, scen_idx::Int; kwargs...) 
+function customize_sub_model!(model::Model, data::AbstractData, scen_idx::Int; kwargs...)
     throw(UndefError("update customize_sub_model! for $(typeof(data))"))
 end
 


### PR DESCRIPTION
…cle subtypes used in `SeparableOracle`

Added the error message to clearly state the required constructor signature for use with SeparableOracle.

Address #48